### PR TITLE
add chartkick graphs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'devise'
+gem 'groupdate'
+gem 'chartkick'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.2)
     byebug (8.2.2)
+    chartkick (1.4.2)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -68,6 +69,8 @@ GEM
     execjs (2.6.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    groupdate (2.5.2)
+      activesupport (>= 3)
     haml (4.0.7)
       tilt
     haml-rails (0.9.0)
@@ -186,8 +189,10 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass (>= 3.3.6)
   byebug
+  chartkick
   coffee-rails (~> 4.1.0)
   devise
+  groupdate
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/views/foods/index.html.haml
+++ b/app/views/foods/index.html.haml
@@ -1,4 +1,6 @@
 %div.row
+  = line_chart Food.group_by_day(:created_at).sum(:cost)
+%div.row
   %div.col-md-6
     %label
       This week: #{this_week}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Drift</title>
+  <%= javascript_include_tag "https://www.google.com/jsapi", "chartkick" %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,20 +5,20 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: drift_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: drift_test
 
 production:
   adapter: postgresql


### PR DESCRIPTION
fixes https://github.com/cartoloupe/drift/issues/25

Notes:
`chartkick` uses `groupdate`, which uses timezone methods only available in postgres db's
- [x] migrated development and test db's to postgres
  - followed procedure outlined in [this Railscast](http://railscasts.com/episodes/342-migrating-to-postgresql?view=asciicast)

<img width="1206" alt="screen shot 2016-03-29 at 7 37 32 pm" src="https://cloud.githubusercontent.com/assets/4593934/14127490/4ba87744-f5e6-11e5-99fe-cc6ba948d393.png">
